### PR TITLE
Allow tests to run with node 0.10

### DIFF
--- a/test/array-destructuring.js
+++ b/test/array-destructuring.js
@@ -784,13 +784,13 @@ describe('Destructuring Array', function() {
           return [a, b];
         }([1, 2]), d = c.next();
       */}),
-      function() {
+      getComment(function() {/*
         var c = function* (b) {
           var $0 = yield b, a = $0[0], b = $0[1];
           return [a, b];
         }([1, 2]), d = c.next();
-      }
-    ).andAssert(
+      */})
+    ).andAssertIf(
       // you'll need node devel for this
       function() {
         d.value[0] === 1 && d.value[1] === 2;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -50,8 +50,17 @@ function assertSrcEquals(referenceFn, compareFn) {
   var referenceSrc = makeSrc(referenceFn);
   var transformedReferenceSrc = sanitizeSource(transformSource(referenceSrc, codegenOptions));
   var compareSrc = makeSrc(compareFn);
+
   assert.strictEqual(transformedReferenceSrc, compareSrc);
+
   return {
+    andAssertIf: function (assertFn) {
+      try {
+        this.andAssert(assertFn);
+      } catch (e) {
+        if (!(e instanceof SyntaxError)) throw e;
+      }
+    },
     andAssert: function(assertFn) {
       var assertSrc = makeSrc(assertFn);
       if (supportsDestructuring) {

--- a/test/object-destructuring.js
+++ b/test/object-destructuring.js
@@ -140,13 +140,13 @@ describe('Destructuring Object', function() {
           return {a: a, b: b};
         }({a: 1, b: 2}), d = c.next();
       */}),
-      function() {
+      getComment(function() {/*
         var c = function* (b) {
           var $0 = yield b, a = $0.a, b = $0.b;
           return {a: a, b: b};
         }({a: 1, b: 2}), d = c.next();
-      }
-    ).andAssert(
+      */})
+    ).andAssertIf(
       function() {
         d.value.a === 1 && d.value.b === 2;
       }


### PR DESCRIPTION
Tested with node v0.10.28 and v0.11.13. Tests run with `.andAssertIf` ignore the result if there is a `SyntaxError`
